### PR TITLE
Workaround for a bug in java.beans.Introspector

### DIFF
--- a/JavaBeanTester.java
+++ b/JavaBeanTester.java
@@ -32,6 +32,7 @@ public class JavaBeanTester {
                     continue nextProp;
                 }
             }
+            findBooleanIsMethods(clazz, prop);
             final Method getter = prop.getReadMethod();
             final Method setter = prop.getWriteMethod();
             
@@ -122,6 +123,32 @@ public class JavaBeanTester {
                     + JavaBeanTester.class.getName() + " class to do this.");
             return null; // for the compiler
         }
+    }
+
+    /**
+     * Hunt down missing Boolean read method if needed as Introspector cannot find 'is' getters
+     * for Boolean type properties.
+     * 
+     * @param clazz
+     *            the type being introspected
+     * @param descriptor
+     *            the property descriptor found so far
+     */
+    public static <T> void findBooleanIsMethods(Class<T> clazz, PropertyDescriptor descriptor) throws IntrospectionException {
+            if ( needToFindReadMethod(descriptor) ) {
+                findTheReadMethod(descriptor, clazz);
+            }
+    }
+
+    private static boolean needToFindReadMethod(PropertyDescriptor property) {
+        return property.getReadMethod() == null && property.getPropertyType() == Boolean.class;
+    }
+
+    private static <T> void findTheReadMethod(PropertyDescriptor descriptor, Class<T> clazz) {
+        try {
+            PropertyDescriptor pd = new PropertyDescriptor(descriptor.getName(), clazz);
+            descriptor.setReadMethod(pd.getReadMethod());
+        } catch (IntrospectionException e) {}
     }
 }
 


### PR DESCRIPTION
The current code using java.beans.Introspector doesn't work with 'is' getters for Boolean properties. Here's the fix for that. 
(Same fix is used in Apache JSP 2.0 EL interpreter: https://issues.apache.org/jira/browse/EL-13)
